### PR TITLE
Small Code Updates to support Python3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: [3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ pytest:
       junit: pytest.xml
   parallel:
     matrix:
-      - PY_VERSION: ["3.7", "3.8"]
+      - PY_VERSION: ["3.8", "3.9", "3.10", "3.11"]
         DUMMY: "0"
 
 .integration:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ pytest:
       junit: pytest.xml
   parallel:
     matrix:
-      - PY_VERSION: ["3.8", "3.9", "3.10", "3.11"]
+      - PY_VERSION: ["3.9", "3.10", "3.11"]
         DUMMY: "0"
 
 .integration:

--- a/.pylintrc
+++ b/.pylintrc
@@ -77,13 +77,7 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
-single-line-if-stmt=no
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
+single-line-if-stmt=n
 
 # Maximum number of lines in a module
 max-module-lines=1000
@@ -121,63 +115,32 @@ property-classes=abc.abstractproperty
 # Regular expression matching correct argument names
 argument-rgx=[a-z_][a-z0-9_]{2,30}$
 
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
-
 # Regular expression matching correct variable names
 variable-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct method names
 method-rgx=(([a-z_][a-z0-9_]{2,60})|(test_[a-z0-9_]{2,100}))$
 
-# Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,60}$
-
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,60}$
 
-# Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,60}$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,60}|(__.*__))$
-
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,60}|(__.*__))$
 
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
 # Regular expression matching correct module names
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,60}$
-
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,60}$
-
 # Regular expression which should only match function or class names that do
 # not require a docstring.
 no-docstring-rgx=^_
@@ -330,4 +293,4 @@ analyse-fallback-blocks=no
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 
 COPY requirements.txt dev-requirements.txt /
 RUN pip install -r requirements.txt &&\

--- a/cimpyorm/Model/Schema.py
+++ b/cimpyorm/Model/Schema.py
@@ -12,7 +12,7 @@ import json
 from argparse import Namespace
 import os
 from collections import ChainMap, defaultdict
-from typing import Iterable
+from collections.abc import Iterable
 from defusedxml.lxml import parse
 import networkx as nx
 from networkx import DiGraph, bfs_tree, dfs_tree

--- a/cimpyorm/Model/Schema.py
+++ b/cimpyorm/Model/Schema.py
@@ -11,8 +11,8 @@
 import json
 from argparse import Namespace
 import os
-from collections import ChainMap, Iterable, defaultdict
-
+from collections import ChainMap, defaultdict
+from typing import Iterable
 from defusedxml.lxml import parse
 import networkx as nx
 from networkx import DiGraph, bfs_tree, dfs_tree

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name='cimpyorm',  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.9.5',  # Required
+    version='0.10.0',  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="A database-backed ORM for CIM datasets.",  # Required
     # https://packaging.python.org/specifications/core-metadata/#description-optional
@@ -39,12 +39,12 @@ setup(
     author_email="t.offergeld@iaew.rwth-aachen.de",  # Optional
     # For a list of valid classifiers, see https://pypi.org/classifiers/
     classifiers=[
-        'Development Status :: 3 - Alpha', 'Intended Audience :: Developers',
+        'Development Status :: 3 - Alpha', 
+        'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License', 'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8'
         'Programming Language :: Python :: 3.9'
         'Programming Language :: Python :: 3.10'
         'Programming Language :: Python :: 3.11'

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name='cimpyorm',  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.9.4',  # Required
+    version='0.9.5',  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="A database-backed ORM for CIM datasets.",  # Required
     # https://packaging.python.org/specifications/core-metadata/#description-optional
@@ -44,8 +44,10 @@ setup(
         'License :: OSI Approved :: BSD License', 'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.10'
+        'Programming Language :: Python :: 3.11'
     ],  # Optional
     packages=find_packages(exclude=[
         'cimpyorm/Test/Deployment/**',


### PR DESCRIPTION
When using cimpyorm with python 3.11 there is an Import Error for `from collections import ..., Iterable, ...`
see also:
```
The Iterable abstract class was removed from collections in Python 3.10. See the deprecation note in the 3.9 [collections docs](https://docs.python.org/3.9/library/collections.html). In the section [Removed](https://docs.python.org/3/whatsnew/3.10.html#removed) of the 3.10 docs, the item

Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the collections module. (Contributed by Victor Stinner in bpo-37324.)
```

This PR fixes the Code Issue. 

Additionally i adjusted the pylintrc config (got some warnings) and GitlabCI + GithubAction config to support for a broader range of Python Versions being tested 