### PR TITLE
Build-System Fixes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.11
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: "3.11"
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,12 @@ setup(
         'Development Status :: 3 - Alpha', 
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License', 'Natural Language :: English',
+        'License :: OSI Approved :: BSD License', 
+        'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9'
-        'Programming Language :: Python :: 3.10'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11'
     ],  # Optional
     packages=find_packages(exclude=[


### PR DESCRIPTION
The last PR had some flaws breaking the workflow, sorry for the inconvenience.

a) the yaml python versions were no strings, hence "3.10"  was treated as a float and represented as "3.1" breaking the test".
b) the setup.py missed some commas, breaking the classifiers, which rejects pushes to pypi