### PR TITLE
fix(release): remove test-pypi release step

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,12 +61,6 @@ jobs:
           python -m pip install build
       - name: Build dist
         run: python -m build --sdist --wheel --outdir dist/ .
-      - name: Publish package (TEST)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TEST_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
       - name: Publish package (PRODUCTION)
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name='cimpyorm',  # Required
     # https://www.python.org/dev/peps/pep-0440/
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.10.0',  # Required
+    version='0.10.1',  # Required
     # https://packaging.python.org/specifications/core-metadata/#summary
     description="A database-backed ORM for CIM datasets.",  # Required
     # https://packaging.python.org/specifications/core-metadata/#description-optional


### PR DESCRIPTION
@mspi92 looks like a previous build pushed to test.pypi, which prevented the push on prod pypi.
I think since this repo was moved from gitlab to github, the process wasn't tested that much.